### PR TITLE
Close #79: Account for Region Overlap in Help Box position

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2019,8 +2019,6 @@ class CGCOOKIE_OT_contours(bpy.types.Operator):
         self.settings = settings
         self.keymap = key_maps.rtflow_default_keymap_generate()
         
-        regOverlap = context.user_preferences.system.use_region_overlap
-        
         my_dir = os.path.split(os.path.abspath(__file__))[0]
         filename = os.path.join(my_dir, "help/help_contours.txt")
         if os.path.isfile(filename):
@@ -2028,7 +2026,7 @@ class CGCOOKIE_OT_contours(bpy.types.Operator):
         else:
             help_txt = "No Help File found, please reinstall!"
 
-        self.help_box = TextBox(context,500,500,300,200,10,20,regOverlap,help_txt)
+        self.help_box = TextBox(context,500,500,300,200,10,20,help_txt)
         self.help_box.collapse()
         self.help_box.snap_to_corner(context, corner = [1,1])
         
@@ -2241,8 +2239,6 @@ class PolystripsUI:
         self.footer = ''
         self.footer_last = ''
         
-        regOverlap = context.user_preferences.system.use_region_overlap
-        
         my_dir = os.path.split(os.path.abspath(__file__))[0]
         filename = os.path.join(my_dir, "help/help_polystrips.txt")
         if os.path.isfile(filename):
@@ -2250,7 +2246,7 @@ class PolystripsUI:
         else:
             help_txt = "No Help File found, please reinstall!"
 
-        self.help_box = TextBox(context,500,500,300,200,10,20, regOverlap, help_txt)
+        self.help_box = TextBox(context,500,500,300,200,10,20, help_txt)
         self.help_box.collapse()
         self.help_box.snap_to_corner(context, corner = [1,1])
 

--- a/lib/common_classes.py
+++ b/lib/common_classes.py
@@ -38,14 +38,13 @@ from . import common_drawing
 
 class TextBox(object):
     
-    def __init__(self,context,x,y,width,height,border, margin, regOverlap, message):
+    def __init__(self,context,x,y,width,height,border, margin, message):
         
         self.x = x
         self.y = y
         self.def_width = width
         self.def_height = height
         self.hang_indent = '-'
-        self.regOverlap = regOverlap
         
         self.width = width
         self.height = height
@@ -63,11 +62,11 @@ class TextBox(object):
         self.text_lines = []
         self.format_and_wrap_text()
 
-    def discover_T_panel_width_and_location(self):
+    def discover_panel_width_and_location(self, panelType):
         for area in bpy.context.screen.areas:
             if area.type == 'VIEW_3D':
                 for reg in area.regions:
-                    if reg.type == 'TOOL_PROPS':
+                    if reg.type == panelType:
                         if reg.width > 1:
                             if reg.x == 0:
                                 return 0
@@ -75,20 +74,7 @@ class TextBox(object):
                                 return reg.width
                         else:
                             return 0
-                            
-    def discover_N_panel_width_and_location(self):
-        for area in bpy.context.screen.areas:
-            if area.type == 'VIEW_3D':
-                for reg in area.regions:
-                    if reg.type == 'UI':
-                        if reg.width > 1:
-                            if reg.x == 0:
-                                return 0
-                            else:
-                                return reg.width
-                        else:
-                            return 0
-                            
+                        
     def screen_boudaries(self):
         print('to be done later')
 
@@ -216,6 +202,8 @@ class TextBox(object):
         return
     
     def draw(self):
+        regOverlap = bpy.context.user_preferences.system.use_region_overlap
+        
         bgcol = bpy.context.user_preferences.themes[0].user_interface.wcol_menu_item.inner
         bgR = bgcol[0]
         bgG = bgcol[1]
@@ -237,9 +225,9 @@ class TextBox(object):
         bordA = .8
         border_color = (bordR, bordG, bordB, bordA)
         
-        if self.regOverlap == True:
-            tPan = self.discover_T_panel_width_and_location()
-            nPan = self.discover_N_panel_width_and_location()
+        if regOverlap == True:
+            tPan = self.discover_panel_width_and_location('TOOL_PROPS')
+            nPan = self.discover_panel_width_and_location('UI')
             if tPan != 0 and nPan != 0:
                 left = (self.x - self.width/2) - (nPan + tPan)
             elif tPan != 0:


### PR DESCRIPTION
Automatic detection of all N and T panel configurations and widths with Region Overlap enabled.
