### PR TITLE
Improve performance by not calling inspect.stack()

### DIFF
--- a/lib/common_utilities.py
+++ b/lib/common_utilities.py
@@ -64,17 +64,20 @@ def selection_mouse():
     return ['%sMOUSE' % select_type, 'SHIFT+%sMOUSE' % select_type]
 
 def get_settings():
-    addons = bpy.context.user_preferences.addons
-    stack = inspect.stack()
-    for entry in stack:
-        folderpath = os.path.dirname(entry[1])
-        foldername = os.path.basename(folderpath)
-        if foldername in {'lib','addons'}: continue
-        if foldername in addons: break
-    else:
-        assert False, 'could not find non-"lib" folder'
-    settings = addons[foldername].preferences
-    return settings
+    if not get_settings.cached_settings:
+        addons = bpy.context.user_preferences.addons
+        frame = inspect.currentframe()
+        while frame:
+            folderpath = os.path.dirname(frame.f_code.co_filename)
+            foldername = os.path.basename(folderpath)
+            frame = frame.f_back
+            if foldername in {'lib','addons'}: continue
+            if foldername in addons: break
+        else:
+            assert False, 'could not find non-"lib" folder'
+        get_settings.cached_settings = addons[foldername].preferences
+    return get_settings.cached_settings
+get_settings.cached_settings = None
 
 def get_source_object():
     settings = get_settings()

--- a/lib/common_utilities.py
+++ b/lib/common_utilities.py
@@ -181,10 +181,10 @@ class Profiler(object):
     
     def start(self, text=None):
         if not text:
-            st = inspect.stack()
-            filename = os.path.split(st[1][1])[1]
-            linenum  = st[1][2]
-            fnname   = st[1][3]
+            frame = inspect.currentframe().f_back
+            filename = os.path.basename( frame.f_code.co_filename )
+            linenum = frame.f_lineno
+            fnname = frame.f_code.co_name
             text = '%s (%s:%d)' % (fnname, filename, linenum)
         return self.ProfilerHelper(self, text)
     


### PR DESCRIPTION
This pull makes a few improvements:

1. Significantly speed up profiler. Each call to the profiler was using inspect.stack(), which gathers lots of information on the entire callstack. However, most of this information was being discarded. I changed it to just get the information it needs from the stack. This speeds up profiling significantly, depending on how deep the stack is (since it now takes constant time). Some benchmarks from my laptop: 1 frame deep takes 5% of the original time, 30 frames deep takes 0.4% of the original time.

2. Speed up get_settings() call. This is called *all the time* and was making use of inspect.stack(). From my testing on the master branch, as much as 20% of each frame rendered was in this function. I sped up the call by avoiding the inspect.stack() call, and also cache the results. If you don't want the settings object to be a singleton then we can remove the caching.


(You know about python's built-in profilers like cProfile, right? It doesn't give you the nice callstack your profiler does (assuming you called the profiler at each level in the stack), but it is much lower overhead and profiles all function calls, not just the ones you instrument)