### PR TITLE
Fix API changes from Blender 2.77

### DIFF
--- a/lib/common_utilities.py
+++ b/lib/common_utilities.py
@@ -309,7 +309,7 @@ def ray_cast_path(context, ob, screen_coords):
         rays = [(get_ray_origin(ray_o, ray_v, ob),get_ray_origin(ray_o, -ray_v, ob)) for ray_o,ray_v in rays]
     
     hits = [ob.ray_cast(imx * ray_o, imx * ray_v) for ray_o,ray_v in rays]
-    world_coords = [mx*co for co,no,face in hits if face != -1]
+    world_coords = [mx*co for ok,co,no,face in hits if ok]
     return world_coords
 
 def ray_cast_path_bvh(context, bvh, mx, screen_coords):
@@ -356,7 +356,7 @@ def ray_cast_stroke(context, ob, stroke):
     
     sten = [(imx*(o-mult*back*d), imx*(o+mult*d)) for o,d in rays]
     hits = [ob.ray_cast(st,st+(en-st)*1000) for st,en in sten]
-    world_stroke = [(mx*hit[0],stroke[i][1])  for i,hit in enumerate(hits) if hit[2] != -1]
+    world_stroke = [(mx*hit[0],stroke[i][1])  for i,hit in enumerate(hits) if hit[0]]
     
     return world_stroke
 
@@ -497,8 +497,8 @@ def ray_cast_world_size(region, rv3d, screen_coord, screen_size, ob, settings):
     
     ray_start_local  = imx * ray_origin
     ray_target_local = imx * ray_target
-    pt_local,no,idx  = ob.ray_cast(ray_start_local, ray_target_local)
-    if idx == -1: return float('inf')
+    ok, pt_local,no,idx  = ob.ray_cast(ray_start_local, ray_target_local)
+    if ok: return float('inf')
     
     pt = mx * pt_local
     

--- a/op_contours/contour_classes.py
+++ b/op_contours/contour_classes.py
@@ -1046,7 +1046,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
                 if bvh:
                     imx = mx.inverted()
                     for i, vert in enumerate(segment):
-                        snap = bvh.find(imx * vert)
+                        snap = bvh.find_nearest(imx * vert)
                         segment[i] = mx * snap[0]
             
             self.world_path.extend(segment)
@@ -1061,14 +1061,14 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
         imx = mx.inverted()
         if raw and len(self.raw_world):
             for i, vert in enumerate(self.raw_world):
-                snap = bvh.find(imx * vert)
+                snap = bvh.find_nearest(imx * vert)
                 self.raw_world[i] = mx * snap[0]
                    
         if world and len(self.world_path):
             #self.path_normals = []
             #self.path_seeds = []
             for i, vert in enumerate(self.world_path):
-                snap = bvh.find(imx * vert)
+                snap = bvh.find_nearest(imx * vert)
                 self.world_path[i] = mx * snap[0]
                 #self.path_normals.append(mx.to_3x3() * snap[1])
                 #self.path_seeds.append(snap[2])
@@ -1077,7 +1077,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
             self.cut_point_normals = []
             self.cut_point_seeds = []
             for i, vert in enumerate(self.cut_points):
-                snap = bvh.find(imx * vert)
+                snap = bvh.find_nearest(imx * vert)
                 self.cut_points[i] = mx * snap[0]
                 self.cut_point_normals.append(mx.to_3x3() * snap[1])
                 self.cut_point_seeds.append(snap[2])
@@ -1264,7 +1264,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
         for i, cut in enumerate(self.cuts):
             
             pt = cut.verts_simple[0]
-            snap = bvh.find(imx * pt)
+            snap = bvh.find_nearest(imx * pt)
             seed = snap[2]
             surface_no = imx.transposed() * snap[1]
             
@@ -1289,7 +1289,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
                 else:
                     diag = contour_utilities.diagonal_verts(cut.verts_simple)
                     cast_point = cut.verts_simple[0] - diag * cut.plane_no
-                    cast_sfc = bvh.find(imx * cast_point)[0]
+                    cast_sfc = bvh.find_nearest(imx * cast_point)[0]
                     vertebra3d = [cut.verts_simple[0], cast_sfc]
                 
                 self.backbone.append(vertebra3d)
@@ -1314,7 +1314,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
                 else:
                     diag = contour_utilities.diagonal_verts(cut.verts_simple)
                     cast_point = cut.verts_simple[0] - diag * cut.plane_no
-                    cast_sfc = bvh.find(imx * cast_point)[0]
+                    cast_sfc = bvh.find_nearest(imx * cast_point)[0]
                     vertebra3d = [cut.verts_simple[0], cast_sfc]
                 
                 self.backbone.append(vertebra3d)
@@ -1357,7 +1357,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
             diag = contour_utilities.diagonal_verts(cut.verts_simple)
     
             cast_point = cut.verts_simple[0] + diag * cut.plane_no
-            cast_sfc = bvh.find(imx * cast_point)[0]
+            cast_sfc = bvh.find_nearest(imx * cast_point)[0]
             vertebra3d = [cast_sfc, cut.verts_simple[0]]
         
         self.backbone.append(vertebra3d)
@@ -1373,7 +1373,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
         imx = mx.inverted()
         ind = self.cuts.index(cut)
         pt = cut.verts_simple[0]
-        snap = bvh.find(imx * pt)
+        snap = bvh.find_nearest(imx * pt)
         seed = snap[2]
         surface_no = imx.transposed() * snap[1]
         
@@ -1393,7 +1393,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
                 diag = contour_utilities.diagonal_verts(self.cuts[0].verts_simple)
         
                 cast_point = self.cuts[0].verts_simple[0] - diag * self.cuts[0].plane_no
-                cast_sfc = bvh.find(imx * cast_point)[0]
+                cast_sfc = bvh.find_nearest(imx * cast_point)[0]
                 vertebra3d = [cast_sfc, self.cuts[0].verts_simple[0]]
             
             self.backbone.pop(0)
@@ -1456,7 +1456,7 @@ class ContourCutSeries(object):  #TODO:  nomenclature consistency. Segment, Segm
             else:
                 diag = contour_utilities.diagonal_verts(cut.verts_simple)
                 cast_point = cut.verts_simple[0] + diag * cut.plane_no
-                cast_sfc = bvh.find(imx * cast_point)[0]
+                cast_sfc = bvh.find_nearest(imx * cast_point)[0]
                 vertebra3d = [cast_sfc, cut.verts_simple[0]]
             
             if not insert:

--- a/op_contours/contour_utilities.py
+++ b/op_contours/contour_utilities.py
@@ -1245,10 +1245,7 @@ def com_mid_ray_test(new_cut, established_cut, obj, search_factor = .5):
             
     hit = obj.ray_cast(imx * (C + search_radius * ray), imx * (C - search_radius * ray))
             
-    if hit[2] != -1:
-        return True
-    else:
-        return False
+    return hit[0]
         
 def com_line_cross_test(com1, com2, pt, no, factor = 2):
     '''

--- a/op_edgeslide/edgeslide_data.py
+++ b/op_edgeslide/edgeslide_data.py
@@ -245,7 +245,7 @@ class EdgeSlide(object):
                 self.vert_snaps_local += [v]
                 self.vert_snaps_world += [mx_trg * v]
             else:
-                loc, no, indx, d = self.src_bvh.find(imx_src * mx_trg * v)
+                loc, no, indx, d = self.src_bvh.find_nearest(imx_src * mx_trg * v)
                 self.vert_snaps_local += [imx_trg * mx_src * loc]
                 self.vert_snaps_world += [mx_src * loc]
                 self.world_right += [mx_trg * (v + self.edge_loop_right[i])]

--- a/op_eyedropper/eyedropper_modal.py
+++ b/op_eyedropper/eyedropper_modal.py
@@ -103,7 +103,7 @@ class  CGC_EyeDropper(ModalOperator):
         view_vector = region_2d_to_vector_3d(region, rv3d, coord)
         ray_origin = region_2d_to_origin_3d(region, rv3d, coord)
         ray_target = ray_origin + (view_vector * ray_max)
-        result, ob, mx, loc, normal = scene.ray_cast(ray_origin, ray_target)
+        result, loc, normal, idx, ob, mx = scene.ray_cast(ray_origin, ray_target)
         
         if result:
             self.ob = ob

--- a/op_loopcut/loopcut_data.py
+++ b/op_loopcut/loopcut_data.py
@@ -158,7 +158,7 @@ class LoopCut(object):
                 self.vert_snaps_local += [v]
                 self.vert_snaps_world += [mx_trg * v]
             else:
-                loc, no, indx, d = self.src_bvh.find(imx_src * mx_trg * v)
+                loc, no, indx, d = self.src_bvh.find_nearest(imx_src * mx_trg * v)
                 self.vert_snaps_local += [imx_trg * mx_src * loc]
                 self.vert_snaps_world += [mx_src * loc]
        

--- a/op_polystrips/polystrips_datastructure.py
+++ b/op_polystrips/polystrips_datastructure.py
@@ -243,10 +243,10 @@ class GVert:
             self.corner2.x = max(0.0, self.corner2.x)
             self.corner3.x = max(0.0, self.corner3.x)
         
-        self.corner0 = mx * bvh.find(imx*self.corner0)[0]  #todo...error?
-        self.corner1 = mx * bvh.find(imx*self.corner1)[0]
-        self.corner2 = mx * bvh.find(imx*self.corner2)[0]
-        self.corner3 = mx * bvh.find(imx*self.corner3)[0]
+        self.corner0 = mx * bvh.find_nearest(imx*self.corner0)[0]  #todo...error?
+        self.corner1 = mx * bvh.find_nearest(imx*self.corner1)[0]
+        self.corner2 = mx * bvh.find_nearest(imx*self.corner2)[0]
+        self.corner3 = mx * bvh.find_nearest(imx*self.corner3)[0]
         
         if Polystrips.settings.symmetry_plane == 'x':
             self.corner0.x = max(0.0, self.corner0.x)
@@ -273,7 +273,7 @@ class GVert:
         mx3x3 = mx.to_3x3()
         
         if not self.frozen:
-            l,n,i, d = bvh.find(imx*self.position)
+            l,n,i, d = bvh.find_nearest(imx*self.position)
             self.snap_norm = (mxnorm * n).normalized()
             self.snap_pos  = mx * l
             self.position = self.snap_pos
@@ -803,7 +803,7 @@ class GEdge:
         bvh = mesh_cache['bvh']
         imx = mx.inverted()
         p3d = [cubic_bezier_blend_t(p0,p1,p2,p3,t/precision) for t in range(precision+1)]
-        p3d = [mx*bvh.find(imx * p)[0] for p in p3d]
+        p3d = [mx*bvh.find_nearest(imx * p)[0] for p in p3d]
         return sum((p1-p0).length for p0,p1 in zip(p3d[:-1],p3d[1:]))
         #return cubic_bezier_length(p0,p1,p2,p3)
     
@@ -942,13 +942,13 @@ class GEdge:
             mx3x3  = mx.to_3x3()
             imx    = mx.inverted()
             p3d      = [cubic_bezier_blend_t(p0,p1,p2,p3,t/16.0) for t in range(17)]
-            snap     = [bvh.find(imx*p) for p in p3d]
+            snap     = [bvh.find_nearest(imx*p) for p in p3d]
             snap_pos = [mx*pos for pos,norm,idx,d in snap]
             bez = cubic_bezier_fit_points(snap_pos, min(r0,r3)/20, allow_split=False)
             if bez:
                 _,_,p0,p1,p2,p3 = bez[0]
-                _,n1,_,_ = bvh.find(imx*p1)
-                _,n2,_,_ = bvh.find(imx*p2)
+                _,n1,_,_ = bvh.find_nearest(imx*p1)
+                _,n2,_,_ = bvh.find_nearest(imx*p2)
                 n1 = mxnorm*n1
                 n2 = mxnorm*n2
         
@@ -1082,7 +1082,7 @@ class GEdge:
         imx = mx.inverted()
         
         for igv in self.cache_igverts:
-            l,n,i,d = bvh.find(imx * igv.position)
+            l,n,i,d = bvh.find_nearest(imx * igv.position)
             igv.position = mx * l
             
             if Polystrips.settings.symmetry_plane == 'x':
@@ -1291,7 +1291,7 @@ class GPatch:
         ge0,ge1,ge2 = self.gedges
         rev0,rev1,rev2 = self.rev
         bvh = mesh_cache['bvh']
-        closest_point_on_mesh = bvh.find
+        closest_point_on_mesh = bvh.find_nearest
         sz0,sz1,sz2 = [len(ge.cache_igverts) for ge in self.gedges]
         
         # defer update for a bit (counts don't match up!)
@@ -1392,7 +1392,7 @@ class GPatch:
         bvh = mesh_cache['bvh']
         ge0,ge1,ge2,ge3 = self.gedges
         rev0,rev1,rev2,rev3 = self.rev
-        closest_point_on_mesh = bvh.find
+        closest_point_on_mesh = bvh.find_nearest
         sz0,sz1,sz2,sz3 = [len(ge.cache_igverts) for ge in self.gedges]
         
         # defer update for a bit (counts don't match up!)
@@ -1478,7 +1478,7 @@ class GPatch:
         bvh = mesh_cache['bvh']
         ge0,ge1,ge2,ge3,ge4 = self.gedges
         rev0,rev1,rev2,rev3,rev4 = self.rev
-        closest_point_on_mesh = bvh.find
+        closest_point_on_mesh = bvh.find_nearest
         sz0,sz1,sz2,sz3,sz4 = [(len(ge.cache_igverts)-1)//2 -1 for ge in self.gedges]
         
         # defer update for a bit (counts don't match up!)
@@ -2324,8 +2324,8 @@ class Polystrips(object):
                             else:
                                 p2 = gvert.position-gvert.tangent_y*gvert.radius
                                 p3 = gvert.position+gvert.tangent_y*gvert.radius
-                                p2 = mx * bvh.find(imx*p2)[0]
-                                p3 = mx * bvh.find(imx*p3)[0]
+                                p2 = mx * bvh.find_nearest(imx*p2)[0]
+                                p3 = mx * bvh.find_nearest(imx*p3)[0]
                                 cc2 = insert_vert(p2)
                                 cc3 = insert_vert(p3)
                             
@@ -2369,12 +2369,12 @@ class Polystrips(object):
                         else:
                             if ge.zip_side*ge.zip_dir == 1:
                                 p3 = gvert.position+gvert.tangent_y*gvert.radius
-                                p3 = mx * bvh.find(imx*p3)[0]
+                                p3 = mx * bvh.find_nearest(imx*p3)[0]
                                 cc3 = insert_vert(p3)
                                 cc2 = lzvind[i_z]
                             else:
                                 p2 = gvert.position-gvert.tangent_y*gvert.radius
-                                p2 = mx * bvh.find(imx*p2)[0]
+                                p2 = mx * bvh.find_nearest(imx*p2)[0]
                                 cc2 = insert_vert(p2)
                                 cc3 = lzvind[i_z]
                         

--- a/op_tweak/tweak_ui_tools.py
+++ b/op_tweak/tweak_ui_tools.py
@@ -180,7 +180,7 @@ class Tweak_UI_Tools():
                     divco[bmv.index] += diff * m
         
         for i in divco:
-            bmverts[i].co = mx * bvh.find(imx*divco[i])[0]
+            bmverts[i].co = mx * bvh.find_nearest(imx*divco[i])[0]
         
         bmesh.update_edit_mesh(self.dest_obj.data, tessface=True, destructive=False)
         


### PR DESCRIPTION
This addressed the API changes in Blender 2.77.

* `ob.ray_cast`, and `scene.ray_cast` changed.
* `bvh.find` > `bvh.find_nearest`