### PR TITLE
issue/376 Singleton_updater_none has no clear_state. Blender can hang during module registration

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -35,6 +35,15 @@ except Exception as e:
 			self.error = None
 			self.error_msg = None
 			self.async_checking = None
+
+		def clear_state(self):
+			self._update_ready = None
+			self._update_link = None
+			self._update_version = None
+			self._source_zip = None
+			self._error = None
+			self._error_msg = None
+			
 	updater = Singleton_updater_none()
 	updater.error = "Error initializing updater module"
 	updater.error_msg = str(e)


### PR DESCRIPTION
RetopoFlow Shader Info
  attribs: offset, dotoffset
  uniforms: perspective, object_scale, clip_start, clip_end
```
Exception in module register(): 'C:\\Users\\Jo\\AppData\\Roaming\\Blender Foundation\\Blender\\2.79\\scripts\\addons\\RetopoFlow\\__init__.py'
Traceback (most recent call last):
  File "D:\Applications\blender-2.79-windows64\2.79\scripts\modules\addon_utils.py", line 350, in enable
    mod.register()
  File "C:\Users\Jo\AppData\Roaming\Blender Foundation\Blender\2.79\scripts\addons\RetopoFlow\__init__.py", line 103, in register
    addon_updater_ops.register(bl_info)
  File "C:\Users\Jo\AppData\Roaming\Blender Foundation\Blender\2.79\scripts\addons\RetopoFlow\addon_updater_ops.py", line 958, in register
    updater.clear_state()  # clear internal vars, avoids reloading oddities
AttributeError: 'Singleton_updater_none' object has no attribute 'clear_state'
```

If this exception gets hit during plugin load it seems to deadlock Blender.  