### PR TITLE
[FIX] Fall back to default keyconfig for mouse_select if custom keyconfig missing view3d.select key.

### DIFF
--- a/addon_common/common/blender_preferences.py
+++ b/addon_common/common/blender_preferences.py
@@ -44,10 +44,13 @@ def mouse_select():
     try:
         m = {'LEFTMOUSE': 'LEFT', 'RIGHTMOUSE': 'RIGHT'}
         return m[bpy.context.window_manager.keyconfigs.active.keymaps['3D View'].keymap_items['view3d.select'].type]
+    except:
+        pass
+    try:
+        m = {'LEFTMOUSE': 'LEFT', 'RIGHTMOUSE': 'RIGHT'}
+        return m[bpy.context.window_manager.keyconfigs.default.keymaps['3D View'].keymap_items['view3d.select'].type]
     except Exception as e:
         if not hasattr(mouse_select, 'reported'):
             print('mouse_select: Exception caught')
             print(e)
             mouse_select.reported = True
-
-


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](). _not present at this time_
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [x] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.
---

By default Blender does not export all keymaps when you export a custom keymap (you must select "All Keymaps" in the export dialog). This causes RetopoFlow's `mouse_select` function to throw an exception, making the keymaps default to `right_rf_keymaps`.

This PR introduces an additional check for the default keyconfig's ("Blender") `view3d.select` key.