### PR TITLE
[FIX] Updated blender_manifest.toml

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -22,7 +22,7 @@ website = "https://docs.retopoflow.com/"
 # https://docs.blender.org/manual/en/dev/extensions/tags.html
 tags = ["Modeling", "Mesh"]
 
-blender_version_min = "3.6.0"
+blender_version_min = "4.2.0"
 # Optional: maximum supported Blender version
 # blender_version_max = "5.1.0"
 


### PR DESCRIPTION
Resolved an issue "Unable to parse manifest" due to invalid min blender version.
The `blender_manifest.toml` system did not exist prior to version 4.2, so setting the minimum to 3.6 causes validation errors in Blender 5.0+.

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide]().
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows:**

- [x] I have used the project extensively, but have not contributed previously.