### PR TITLE
[FIX] Fix lags on toolbar hover

### DIFF
--- a/retopoflow/rf/rf_fsm.py
+++ b/retopoflow/rf/rf_fsm.py
@@ -46,6 +46,7 @@ class RetopoFlow_FSM(CookieCutter): # CookieCutter must be here in order to over
     def setup_states(self):
         self.view_version = None
         self._last_rfwidget = None
+        self._last_raycast_state = None
         self.fast_update_timer = self.actions.start_timer(120.0, enabled=False)
 
     def update(self, timer=True):
@@ -96,7 +97,15 @@ class RetopoFlow_FSM(CookieCutter): # CookieCutter must be here in order to over
             self.callback_view_change()
             tag_redraw_all('RF_FSM view change')
 
-        self.actions.hit_pos,self.actions.hit_norm,_,_ = self.raycast_sources_mouse()
+        if self._hover_ui:
+            raycast_state = None
+        else:
+            mouse = self.actions.mouse
+            raycast_state = ((mouse.x, mouse.y) if mouse else None, view_version)
+        if raycast_state is not None and raycast_state != self._last_raycast_state:
+            self._last_raycast_state = raycast_state
+            self.actions.hit_pos,self.actions.hit_norm,_,_ = self.raycast_sources_mouse()
+
         fpsdiv = self.document.body.getElementById('fpsdiv')
         if fpsdiv: fpsdiv.innerText = f'UI FPS: {self.document._draw_fps:.2f}'
 

--- a/retopoflow/rf/rf_tools.py
+++ b/retopoflow/rf/rf_tools.py
@@ -39,6 +39,7 @@ class RetopoFlow_Tools:
 
     def setup_rftools(self):
         self.rftool = None
+        self._updating_rftool_ui = False
 
         # Set class-level flag before creating any tools
         RFTool.defer_recomputing = True
@@ -62,6 +63,8 @@ class RetopoFlow_Tools:
     def _select_rftool(self, rftool, *, reset=True, quick=False):
         assert rftool in self.rftools
 
+        if self._updating_rftool_ui: return False
+
         # return if tool already set
         if rftool == self.rftool:
             if reset: self.reset_rftool()
@@ -78,8 +81,12 @@ class RetopoFlow_Tools:
 
     def _update_rftool_ui(self):
         rftool = self.rftool
-        self.ui_main.getElementById(f'tool-{rftool.name.lower()}').checked = True
-        self.ui_tiny.getElementById(f'ttool-{rftool.name.lower()}').checked = True
+        self._updating_rftool_ui = True
+        try:
+            self.ui_main.getElementById(f'tool-{rftool.name.lower()}').checked = True
+            self.ui_tiny.getElementById(f'ttool-{rftool.name.lower()}').checked = True
+        finally:
+            self._updating_rftool_ui = False
         self.ui_main.dirty(cause='changed tools', children=True)
         self.ui_tiny.dirty(cause='changed tools', children=True)
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](). _not present at this time_
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [x] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

**If the project maintainer has any additional requirements, they will be listed here.**

- No additional requirements.

---

## Problem
Hovering the mouse over the RetopoFlow toolbar freezes for a few seconds and up to a minute, depending on the original model complexity.

## Cause
`update()` runs on every mouse event and always raycasts the source mesh, even when the mouse is over the UI and the result is never used. `modal_mainloop` already knows the UI handled the event (`cookiecutter_modal.py:132`), but it calls `update()` anyway (line 143), and `update()` raycasts at `rf_fsm.py:99`. This produces about 80 raycasts per second while moving over the toolbar

## Proposed fix
Raycast only when the result can change and can be used: skip it while the mouse is over the UI (tool widgets are not drawn then), and reuse the last result while the mouse and the view have not moved.

Related issue, but was closed due to lack of response: https://github.com/CGCookie/retopoflow/issues/1001 
Maybe related: https://github.com/CGCookie/retopoflow/issues/842 https://github.com/CGCookie/retopoflow/issues/1426
